### PR TITLE
Allow absolute redirect url.

### DIFF
--- a/oauthproxy.go
+++ b/oauthproxy.go
@@ -105,6 +105,12 @@ func (p *OauthProxy) GetLoginURL(redirectUrl string) string {
 	if strings.HasPrefix(redirectUrl, "/") {
 		params.Add("state", redirectUrl)
 	}
+
+	redirectUrlObj, _ := url.Parse(redirectUrl)
+	if redirectUrlObj.Host == p.redirectUrl.Host {
+		params.Add("state", redirectUrl)
+	}
+
 	return fmt.Sprintf("%s?%s", p.oauthLoginUrl, params.Encode())
 }
 


### PR DESCRIPTION
Allow absolute redirect url when the host of the url is same as the one of opts.redirectUrl.